### PR TITLE
Dockerfile: update for multi-arch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-.dockerignore
-.git
-.idea
-Dockerfile
-README.md


### PR DESCRIPTION
- remove .dockerignore, as the Dockerfile is already specific enough on what to copy; an ignore-file is redundant.
- add a syntax directive
- add a build-arg to allow overriding the Go version
- remove redundant GOPATH directories, as we're a module now
- set up stages for multi-arch
- document build-args in the dockerfile
